### PR TITLE
Build reproducibility: Do not stamp date or time.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ void signal_term(int sig)
 
 int main(int argc, char** argv)
 {
-	cerr << "Free Music Instrument Tuner version " << PACKAGE_VERSION << " built at " << __DATE__ << " " << __TIME__ << endl;
+	cerr << "Free Music Instrument Tuner version " << PACKAGE_VERSION << endl;
 	cerr << "Install directory '" << PREFIX << "'" << endl;
 
 	signal(SIGINT, signal_interrupt);


### PR DESCRIPTION
Use of `__DATE__` and `__TIME__` macros makes it impossible to produce the
same binary from the same source at a different time.

See https://wiki.debian.org/ReproducibleBuilds/TimestampsFromCPPMacros

(I'm also glad to keep this as a Debian-only patch, or guard it with an ifdef.)