### PR TITLE
Add multimedia to the ALSA Audio Capture System config.

### DIFF
--- a/fmit.pro
+++ b/fmit.pro
@@ -67,6 +67,7 @@ CONFIG(acs_qt) {
 CONFIG(acs_alsa) {
     message(Audio Capture System: Request ALSA support)
     DEFINES += CAPTURE_ALSA
+    QT += multimedia
     SOURCES += src/CaptureThreadImplALSA.cpp
     LIBS += -lasound
 }


### PR DESCRIPTION
This change let me run fmit with ALSA.  So as not to confuse anyone, I also locally changed:
 
https://github.com/romeojulietthotel/fmit/blob/master/fmit.pro#L22

to 

CONFIG += acs_alsa

Then things worked fine in my build using qt580.