### PR TITLE
Autoload scales for microtonal view

### DIFF
--- a/src/modules/MicrotonalView.cpp
+++ b/src/modules/MicrotonalView.cpp
@@ -384,7 +384,11 @@ void MicrotonalView::load()
 		try
 		{
 			MScale* scale = new MScale(*it, MScale::SCALA);
-			setting_scales.push_back(scale);
+			bool new_one = true;
+			for(size_t i=0; new_one && i<setting_scales.size(); i++)
+				new_one = *scale != *(setting_scales[i]);
+			if (new_one)
+				setting_scales.push_back(scale);
 		}
         catch(QString error){cout << "MicrotonalView::load " << error.toStdString() << endl;}
 	}
@@ -887,7 +891,11 @@ void MicrotonalView::load_installed_scales()
 			try
 			{
 				MScale* scale = new MScale(scales_dir.absoluteFilePath(*it), MScale::SCALA);
-				setting_scales.push_back(scale);
+				bool new_one = true;
+				for(size_t i=0; new_one && i<setting_scales.size(); i++)
+					new_one = *scale != *(setting_scales[i]);
+				if (new_one)
+					setting_scales.push_back(scale);
 			}
 		    catch(QString error){cout << "MicrotonalView::load_installed_scales " << error.toStdString() << endl;}
 		}

--- a/src/modules/MicrotonalView.cpp
+++ b/src/modules/MicrotonalView.cpp
@@ -354,6 +354,7 @@ MicrotonalView::MicrotonalView(QWidget* parent)
 	setMaximumHeight(ui_scale->maximumHeight()+ui_ratios->maximumHeight()+20);
 
 	load_default_scales();
+	load_installed_scales();
 
 	refreshScaleList();
 
@@ -871,6 +872,26 @@ void MicrotonalView::load_default_scales()
 	scale->values.push_back(MScale::MValue(48,25));
 	scale->values.push_back(MScale::MValue(125,64));
 	setting_scales.push_back(scale);
+}
+
+void MicrotonalView::load_installed_scales()
+{
+	QString fmitprefix(STR(PREFIX));
+	QDir scales_dir(fmitprefix + "/share/fmit/scales");
+	
+	QStringList scales_files_list = scales_dir.entryList(QDir::Filter::Files);
+	for(QStringList::iterator it=scales_files_list.begin(); it!=scales_files_list.end(); ++it)
+	{
+		if(it->contains(QRegExp("\\.scl$")) || it->contains(QRegExp("\\.SCL$")))
+		{
+			try
+			{
+				MScale* scale = new MScale(scales_dir.absoluteFilePath(*it), MScale::SCALA);
+				setting_scales.push_back(scale);
+			}
+		    catch(QString error){cout << "MicrotonalView::load_installed_scales " << error.toStdString() << endl;}
+		}
+	}
 }
 
 // ------------------ MicrotonalView::ScalePreview --------------------

--- a/src/modules/MicrotonalView.h
+++ b/src/modules/MicrotonalView.h
@@ -99,6 +99,7 @@ class MicrotonalView : public QFrame, public View
 	float m_tuningFreq;
 
 	void load_default_scales();
+	void load_installed_scales();
 
 	vector<QRoot*> m_roots;
 	struct QScaleLabel : QLabel


### PR DESCRIPTION
I think it might make sense to auto-load these scales that are installed together with FMIT. Otherwise, the user might not even notice they exist.

My main motivation is that when using flatpak, the scales will be insalled inside the sandbox, but the open file dialog opens outside the sandbox. This way, the path to the scales inside the sandbox (`/app/share/fmit/scales`) will not exist to the file dialog and so it falls back to some standard directory. The actual path outside the sandbox will be very awkward and most users will not be able to locate it (`/var/lib/flatpak/app/io.github.gillesdegottex.FMIT/current/active/files/share/fmit/scales/`). 

So this was the most straightforward solution I could come up with, and it should work well in non-sandboxed installations too (although I did not test that situation).

What do you think?