### PR TITLE
Auto-load installed scales for microtonal view (take 2)

### DIFF
--- a/src/modules/MicrotonalView.cpp
+++ b/src/modules/MicrotonalView.cpp
@@ -384,7 +384,11 @@ void MicrotonalView::load()
 		try
 		{
 			MScale* scale = new MScale(*it, MScale::SCALA);
-			setting_scales.push_back(scale);
+			bool new_one = true;
+			for(size_t i=0; new_one && i<setting_scales.size(); i++)
+				new_one = *scale != *(setting_scales[i]);
+			if (new_one)
+				setting_scales.push_back(scale);
 		}
         catch(QString error){cout << "MicrotonalView::load " << error.toStdString() << endl;}
 	}
@@ -891,7 +895,11 @@ void MicrotonalView::load_installed_scales()
 			try
 			{
 				MScale* scale = new MScale(scales_dir.absoluteFilePath(*it), MScale::SCALA);
-				setting_scales.push_back(scale);
+				bool new_one = true;
+				for(size_t i=0; new_one && i<setting_scales.size(); i++)
+					new_one = *scale != *(setting_scales[i]);
+				if (new_one)
+					setting_scales.push_back(scale);
 			}
 		    catch(QString error){cout << "MicrotonalView::load_installed_scales " << error.toStdString() << endl;}
 		}

--- a/src/modules/MicrotonalView.cpp
+++ b/src/modules/MicrotonalView.cpp
@@ -354,6 +354,7 @@ MicrotonalView::MicrotonalView(QWidget* parent)
 	setMaximumHeight(ui_scale->maximumHeight()+ui_ratios->maximumHeight()+20);
 
 	load_default_scales();
+	load_installed_scales();
 
 	refreshScaleList();
 
@@ -871,6 +872,30 @@ void MicrotonalView::load_default_scales()
 	scale->values.push_back(MScale::MValue(48,25));
 	scale->values.push_back(MScale::MValue(125,64));
 	setting_scales.push_back(scale);
+}
+
+void MicrotonalView::load_installed_scales()
+{
+	QString fmitprefix(STR(PREFIX));
+	QDir scales_dir(fmitprefix + "/share/fmit/scales");
+	
+#ifdef QT3_SUPPORT
+	QStringList scales_files_list = scales_dir.entryList(QDir::Files);
+#else
+	QStringList scales_files_list = scales_dir.entryList(QDir::Filter::Files);
+#endif
+	for(QStringList::iterator it=scales_files_list.begin(); it!=scales_files_list.end(); ++it)
+	{
+		if(it->contains(QRegExp("\\.scl$")) || it->contains(QRegExp("\\.SCL$")))
+		{
+			try
+			{
+				MScale* scale = new MScale(scales_dir.absoluteFilePath(*it), MScale::SCALA);
+				setting_scales.push_back(scale);
+			}
+		    catch(QString error){cout << "MicrotonalView::load_installed_scales " << error.toStdString() << endl;}
+		}
+	}
 }
 
 // ------------------ MicrotonalView::ScalePreview --------------------

--- a/src/modules/MicrotonalView.h
+++ b/src/modules/MicrotonalView.h
@@ -99,6 +99,7 @@ class MicrotonalView : public QFrame, public View
 	float m_tuningFreq;
 
 	void load_default_scales();
+	void load_installed_scales();
 
 	vector<QRoot*> m_roots;
 	struct QScaleLabel : QLabel


### PR DESCRIPTION
It seems in Qt3 it was `QDir::Files` instead of `QDir::Filter::Files` (Qt4 and Qt5). I've tried to handle that similarly to other parts of the code, but I'm not sure it will work as I have no way to test a Qt3 build. Could you please test it?