### PR TITLE
Fix + Add a couple of note name sets + Suggestion

### DIFF
--- a/libs/Music/Music.h
+++ b/libs/Music/Music.h
@@ -238,32 +238,32 @@ namespace Music
 		if(local==LOCAL_ANGLO)
 		{
 			if(ht==0)	return "A"+soct;
-			else if(ht==1)	return "Bb"+soct;
+			else if(ht==1)	return "B♭"+soct;
 			else if(ht==2)	return "B"+soct;
 			else if(ht==3)	return "C"+soct;
-			else if(ht==4)	return "C#"+soct;
+			else if(ht==4)	return "C♯"+soct;
 			else if(ht==5)	return "D"+soct;
-			else if(ht==6)	return "Eb"+soct;
+			else if(ht==6)	return "E♭"+soct;
 			else if(ht==7)	return "E"+soct;
 			else if(ht==8)	return "F"+soct;
-			else if(ht==9)	return "F#"+soct;
+			else if(ht==9)	return "F♯"+soct;
 			else if(ht==10)	return "G"+soct;
-			else if(ht==11)	return "G#"+soct;
+			else if(ht==11)	return "G♯"+soct;
 		}
 		else if(local==LOCAL_LATIN)
 		{
 			if(ht==0)	return "La"+soct;
-			else if(ht==1)	return "Sib"+soct;
+			else if(ht==1)	return "Si♭"+soct;
 			else if(ht==2)	return "Si"+soct;
 			else if(ht==3)	return "Do"+soct;
-			else if(ht==4)	return "Do#"+soct;
+			else if(ht==4)	return "Do♯"+soct;
 			else if(ht==5)	return "Re"+soct;
-			else if(ht==6)	return "Mib"+soct;
+			else if(ht==6)	return "Mi♭"+soct;
 			else if(ht==7)	return "Mi"+soct;
 			else if(ht==8)	return "Fa"+soct;
-			else if(ht==9)	return "Fa#"+soct;
+			else if(ht==9)	return "Fa♯"+soct;
 			else if(ht==10)	return "Sol"+soct;
-			else if(ht==11)	return "Sol#"+soct;
+			else if(ht==11)	return "Sol♯"+soct;
 		}
 		else if(local==LOCAL_GERMAN)
 		{
@@ -271,14 +271,14 @@ namespace Music
 			else if(ht==1)	return "B"+soct;
 			else if(ht==2)	return "H"+soct;
 			else if(ht==3)	return "C"+soct;
-			else if(ht==4)	return "C#"+soct;
+			else if(ht==4)	return "C♯"+soct;
 			else if(ht==5)	return "D"+soct;
-			else if(ht==6)	return "Eb"+soct;
+			else if(ht==6)	return "E♭"+soct;
 			else if(ht==7)	return "E"+soct;
 			else if(ht==8)	return "F"+soct;
-			else if(ht==9)	return "F#"+soct;
+			else if(ht==9)	return "F♯"+soct;
 			else if(ht==10)	return "G"+soct;
-			else if(ht==11)	return "G#"+soct;
+			else if(ht==11)	return "G♯"+soct;
 		}
 		else if(local==LOCAL_HINDUSTANI)
 		{
@@ -298,17 +298,17 @@ namespace Music
 		else if(local==LOCAL_BYZANTINE)
 		{
 			if(ht==0)	return "Ke"+soct;
-			else if(ht==1)	return "Zob"+soct;
+			else if(ht==1)	return "Zo♭"+soct;
 			else if(ht==2)	return "Zo"+soct;
 			else if(ht==3)	return "Ni"+soct;
-			else if(ht==4)	return "Ni#"+soct;
+			else if(ht==4)	return "Ni♯"+soct;
 			else if(ht==5)	return "Pa"+soct;
-			else if(ht==6)	return "Voub"+soct;
+			else if(ht==6)	return "Vou♭"+soct;
 			else if(ht==7)	return "Vou"+soct;
 			else if(ht==8)	return "Ga"+soct;
-			else if(ht==9)	return "Ga#"+soct;
+			else if(ht==9)	return "Ga♯"+soct;
 			else if(ht==10)	return "Di"+soct;
-			else if(ht==11)	return "Di#"+soct;
+			else if(ht==11)	return "Di♯"+soct;
 		}
 
 		return "Th#1138";

--- a/libs/Music/Music.h
+++ b/libs/Music/Music.h
@@ -34,7 +34,7 @@ using namespace std;
 
 namespace Music
 {
-	enum NotesName{LOCAL_ANGLO, LOCAL_LATIN, LOCAL_GERMAN};
+	enum NotesName{LOCAL_ANGLO, LOCAL_LATIN, LOCAL_GERMAN, LOCAL_HINDUSTANI};
 	extern NotesName s_notes_name;
 	inline NotesName GetNotesName()					{return s_notes_name;}
 	inline void SetNotesName(NotesName type)		{s_notes_name = type;}
@@ -265,7 +265,7 @@ namespace Music
 			else if(ht==10)	return "Sol"+soct;
 			else if(ht==11)	return "Sol#"+soct;
 		}
-		else
+		else if(local==LOCAL_GERMAN)
 		{
 			if(ht==0)	return "A"+soct;
 			else if(ht==1)	return "B"+soct;
@@ -279,6 +279,21 @@ namespace Music
 			else if(ht==9)	return "F#"+soct;
 			else if(ht==10)	return "G"+soct;
 			else if(ht==11)	return "G#"+soct;
+		}
+		else if(local==LOCAL_HINDUSTANI)
+		{
+			if(ht==0)	return "D"+soct;
+			else if(ht==1)	return "n"+soct;
+			else if(ht==2)	return "N"+soct;
+			else if(ht==3)	return "S"+soct;
+			else if(ht==4)	return "r"+soct;
+			else if(ht==5)	return "R"+soct;
+			else if(ht==6)	return "g"+soct;
+			else if(ht==7)	return "G"+soct;
+			else if(ht==8)	return "m"+soct;
+			else if(ht==9)	return "M"+soct;
+			else if(ht==10)	return "P"+soct;
+			else if(ht==11)	return "d"+soct;
 		}
 
 		return "Th#1138";

--- a/libs/Music/Music.h
+++ b/libs/Music/Music.h
@@ -34,7 +34,7 @@ using namespace std;
 
 namespace Music
 {
-	enum NotesName{LOCAL_ANGLO, LOCAL_LATIN, LOCAL_GERMAN, LOCAL_HINDUSTANI};
+	enum NotesName{LOCAL_ANGLO, LOCAL_LATIN, LOCAL_GERMAN, LOCAL_HINDUSTANI, LOCAL_BYZANTINE};
 	extern NotesName s_notes_name;
 	inline NotesName GetNotesName()					{return s_notes_name;}
 	inline void SetNotesName(NotesName type)		{s_notes_name = type;}
@@ -294,6 +294,21 @@ namespace Music
 			else if(ht==9)	return "M"+soct;
 			else if(ht==10)	return "P"+soct;
 			else if(ht==11)	return "d"+soct;
+		}
+		else if(local==LOCAL_BYZANTINE)
+		{
+			if(ht==0)	return "Ke"+soct;
+			else if(ht==1)	return "Zob"+soct;
+			else if(ht==2)	return "Zo"+soct;
+			else if(ht==3)	return "Ni"+soct;
+			else if(ht==4)	return "Ni#"+soct;
+			else if(ht==5)	return "Pa"+soct;
+			else if(ht==6)	return "Voub"+soct;
+			else if(ht==7)	return "Vou"+soct;
+			else if(ht==8)	return "Ga"+soct;
+			else if(ht==9)	return "Ga#"+soct;
+			else if(ht==10)	return "Di"+soct;
+			else if(ht==11)	return "Di#"+soct;
 		}
 
 		return "Th#1138";

--- a/src/CustomInstrumentTunerForm.cpp
+++ b/src/CustomInstrumentTunerForm.cpp
@@ -821,6 +821,7 @@ void CustomInstrumentTunerForm::configure_ok()
 	if(m_config_form.ui_cbNotesName->currentIndex()==0)		SetNotesName(LOCAL_ANGLO);
 	if(m_config_form.ui_cbNotesName->currentIndex()==1)		SetNotesName(LOCAL_LATIN);
 	if(m_config_form.ui_cbNotesName->currentIndex()==2)		SetNotesName(LOCAL_GERMAN);
+	if(m_config_form.ui_cbNotesName->currentIndex()==3)		SetNotesName(LOCAL_HINDUSTANI);
 	m_microtonalView->notesNameChanged();
 	m_microtonalView->setAFreq(Music::GetAFreq());
 

--- a/src/CustomInstrumentTunerForm.cpp
+++ b/src/CustomInstrumentTunerForm.cpp
@@ -818,9 +818,9 @@ void CustomInstrumentTunerForm::configure_ok()
     else if(m_config_form.ui_cbTonality->currentIndex()==2)	SetTonality(-3);
     else if(m_config_form.ui_cbTonality->currentIndex()==3)	SetTonality(-5);
 
-    if(m_config_form.ui_cbNotesName->currentIndex()==0)		SetNotesName(LOCAL_ANGLO);
+	if(m_config_form.ui_cbNotesName->currentIndex()==0)		SetNotesName(LOCAL_ANGLO);
 	if(m_config_form.ui_cbNotesName->currentIndex()==1)		SetNotesName(LOCAL_LATIN);
-	else													SetNotesName(LOCAL_GERMAN);
+	if(m_config_form.ui_cbNotesName->currentIndex()==2)		SetNotesName(LOCAL_GERMAN);
 	m_microtonalView->notesNameChanged();
 	m_microtonalView->setAFreq(Music::GetAFreq());
 

--- a/src/CustomInstrumentTunerForm.cpp
+++ b/src/CustomInstrumentTunerForm.cpp
@@ -822,6 +822,7 @@ void CustomInstrumentTunerForm::configure_ok()
 	if(m_config_form.ui_cbNotesName->currentIndex()==1)		SetNotesName(LOCAL_LATIN);
 	if(m_config_form.ui_cbNotesName->currentIndex()==2)		SetNotesName(LOCAL_GERMAN);
 	if(m_config_form.ui_cbNotesName->currentIndex()==3)		SetNotesName(LOCAL_HINDUSTANI);
+	if(m_config_form.ui_cbNotesName->currentIndex()==4)		SetNotesName(LOCAL_BYZANTINE);
 	m_microtonalView->notesNameChanged();
 	m_microtonalView->setAFreq(Music::GetAFreq());
 

--- a/ui/ConfigForm.ui
+++ b/ui/ConfigForm.ui
@@ -222,6 +222,11 @@ latin: Do Re Mi Fa Sol La Si</string>
              <string>Hindustani</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>Byzantine</string>
+            </property>
+           </item>
           </widget>
          </item>
         </layout>

--- a/ui/ConfigForm.ui
+++ b/ui/ConfigForm.ui
@@ -217,6 +217,11 @@ latin: Do Re Mi Fa Sol La Si</string>
              <string>German</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>Hindustani</string>
+            </property>
+           </item>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
First commit is a fix for a bug I introduced with the German note names.
Second commit adds Hindustani note names.
Third commit adds byzantine note names.
Fourth commit is a suggestion for using the unicode flat/sharp signs. It looks better and is technically more correct, but may cause problems with ancient (like very, very old) fonts. If you object to it I can drop this commit.

I'll do another pull request for updating the translation strings later (I'm also syncing the Transifex project in the process, so the next PR might include more changes).