### PR TITLE
Convert QGLWidget usage to QOpenGLWidget

### DIFF
--- a/src/CustomInstrumentTunerForm.cpp
+++ b/src/CustomInstrumentTunerForm.cpp
@@ -628,31 +628,31 @@ void CustomInstrumentTunerForm::refresh_views()
 {
 // 	cout << "CustomInstrumentTunerForm::refresh_views " << endl;
 
-//	m_dialTune->repaint();
+	m_dialTune->repaint();
 
 	if(m_glGraph->setting_show->isChecked())
-		m_glGraph->updateGL();
+		m_glGraph->update();
 
 	if(m_glErrorHistory->setting_show->isChecked())
-		m_glErrorHistory->updateGL();
+		m_glErrorHistory->update();
 
 	if(m_glVolumeHistory->setting_show->isChecked())
-		m_glVolumeHistory->updateGL();
+		m_glVolumeHistory->update();
 
 	if(m_microtonalView->setting_show->isChecked())
 		m_microtonalView->update();
 
 	if(m_glSample->setting_show->isChecked())
-		m_glSample->updateGL();
+		m_glSample->update();
 
 	if(m_glFreqStruct->setting_show->isChecked())
-		m_glFreqStruct->updateGL();
+		m_glFreqStruct->update();
 
 	if(m_glFT->setting_show->isChecked())
-		m_glFT->updateGL();
+		m_glFT->update();
 
 	if(m_glStatistics->setting_show->isChecked())
-		m_glStatistics->updateGL();
+		m_glStatistics->update();
 
 	m_time_refresh_views.start();
 }

--- a/src/modules/GLErrorHistory.cpp
+++ b/src/modules/GLErrorHistory.cpp
@@ -26,6 +26,7 @@ using namespace std;
 #include <qimage.h>
 #include <qwidgetaction.h>
 #include <qboxlayout.h>
+#include <QPainter>
 #include <Music/Music.h>
 
 void GLErrorHistory::Note::init()
@@ -70,7 +71,7 @@ void GLErrorHistory::Note::addError(float err)
 }
 
 GLErrorHistory::GLErrorHistory(QWidget* parent)
-: QGLWidget(parent)
+: QOpenGLWidget(parent)
 , View(tr("Error history"), this)
 , m_font("Helvetica")
 {
@@ -185,7 +186,9 @@ void GLErrorHistory::drawTextTickCent(int r, int dy)
 	// only work within range that is a pure multiple of r
 	int range = int(setting_spinScale->value()/r)*r;
 
+    QPainter painter(this);
     m_font.setPixelSize(14);
+    painter.setFont(m_font);
     QFontMetrics fm(m_font);
 
 	float scale = 50.0f/setting_spinScale->value();
@@ -197,8 +200,9 @@ void GLErrorHistory::drawTextTickCent(int r, int dy)
 		if(i==0) txt = QString("  ")+txt;
         int y = height()/2 - int(height()*i/100.0f*scale);
         if(y>fm.xHeight() && y<height()-fm.xHeight())
-            renderText(2, y+ fm.xHeight()/2, txt, m_font);
+            painter.drawText(2, y+ fm.xHeight()/2, txt);
     }
+    painter.end();
 }
 
 //void GLErrorHistory::paintEvent(QPaintEvent * event){
@@ -219,8 +223,11 @@ void GLErrorHistory::paintGL()
 
     // name
     glColor3f(0.75,0.75,0.75);
+    QPainter painter(this);
     m_font.setPixelSize(20);
-    renderText(2, 20, tr("Error"), m_font);
+    painter.setFont(m_font);
+    painter.drawText(2, 20, tr("Error"));
+    painter.end();
 
     int char_size = 9;
     int ticks_size = 2+3*char_size;
@@ -279,20 +286,23 @@ void GLErrorHistory::paintGL()
     }
     else
     {
+        painter.begin(this);
         m_font.setPixelSize(14);
+        painter.setFont(m_font);
         QFontMetrics fm(m_font);
         string sfraq, sufraq;
         sufraq = string("1/")+QString::number(int(50/setting_spinScale->value())*2).toStdString();
         sfraq = string("-")+sufraq;
-        renderText(2, 3*height()/4-dy+fm.xHeight(), QString(sfraq.c_str()), m_font);
+        painter.drawText(2, 3*height()/4-dy+fm.xHeight(), QString(sfraq.c_str()));
         sfraq = string("+")+sufraq;
-        renderText(2, height()/4-dy+fm.xHeight(), QString(sfraq.c_str()), m_font);
+        painter.drawText(2, height()/4-dy+fm.xHeight(), QString(sfraq.c_str()));
 
         sufraq = string("1/")+QString::number(int(50/setting_spinScale->value())*4).toStdString();
         sfraq = string("-")+sufraq;
-        renderText(2, 5*height()/8-dy+fm.xHeight(), QString(sfraq.c_str()), m_font);
+        painter.drawText(2, 5*height()/8-dy+fm.xHeight(), QString(sfraq.c_str()));
         sfraq = string("+")+sufraq;
-        renderText(2, 3*height()/8-dy+fm.xHeight(), QString(sfraq.c_str()), m_font);
+        painter.drawText(2, 3*height()/8-dy+fm.xHeight(), QString(sfraq.c_str()));
+        painter.end();
     }
 
     // errors
@@ -324,8 +334,11 @@ void GLErrorHistory::paintGL()
             // the note name
             string str = m_notes[i].getName().toStdString();
             glColor3f(0.0,0.0,1.0);
+            painter.begin(this);
             m_font.setPixelSize(14);
-            renderText(x+2, height()-2, QString(str.c_str()), m_font);
+            painter.setFont(m_font);
+            painter.drawText(x+2, height()-2, QString(str.c_str()));
+            painter.end();
 
             // draw the error graph
             glColor3f(0.0f,0.0f,0.0f);

--- a/src/modules/GLErrorHistory.h
+++ b/src/modules/GLErrorHistory.h
@@ -23,7 +23,7 @@
 
 #include <deque>
 using namespace std;
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <qspinbox.h>
 #include <qsettings.h>
 #include <qaction.h>
@@ -31,7 +31,7 @@ class QTimer;
 #include <Music/Music.h>
 #include "View.h"
 
-class GLErrorHistory : public QGLWidget, public View
+class GLErrorHistory : public QOpenGLWidget, public View
 {
 	Q_OBJECT
 

--- a/src/modules/GLFT.cpp
+++ b/src/modules/GLFT.cpp
@@ -27,6 +27,7 @@ using namespace std;
 #include <qevent.h>
 #include <qboxlayout.h>
 #include <qwidgetaction.h>
+#include <QPainter>
 #include <Music/Music.h>
 #include <Music/SPWindow.h>
 using namespace Music;
@@ -34,7 +35,7 @@ using namespace Music;
 using namespace Math;
 
 GLFT::GLFT(QWidget* parent)
-: QGLWidget(parent)
+: QOpenGLWidget(parent)
 , View(tr("Fourier Transform"), this)
 , m_font("Helvetica")
 , m_components_max(1.0)
@@ -174,7 +175,7 @@ void GLFT::mousePressEvent(QMouseEvent* e)
 
 	double f = (m_maxf-m_minf)*double(m_press_x)/width()+m_minf;
 	m_text = tr("Frequency %1 [Hz]").arg(f);
-	updateGL();
+	update();
 }
 void GLFT::mouseDoubleClickEvent(QMouseEvent* e)
 {
@@ -184,7 +185,7 @@ void GLFT::mouseDoubleClickEvent(QMouseEvent* e)
 	m_minf=0;
 	m_maxf=Music::GetSamplingRate()/2; // sr is surely -1 because not yet defined
 	resetaxis();
-	updateGL();
+	update();
 }
 void GLFT::mouseMoveEvent(QMouseEvent* e)
 {
@@ -223,7 +224,7 @@ void GLFT::mouseMoveEvent(QMouseEvent* e)
 				m_maxA -= m_maxA*double(dy)/height();
 		}
 
-		updateGL();
+		update();
 	}
 
 	old_x = e->x();
@@ -246,8 +247,11 @@ void GLFT::paintGL()
 
 		// name
 		glColor3f(0.75,0.75,0.75);
+		QPainter painter(this);
         m_font.setPixelSize(20);
-        renderText(2, 20, tr("Fourier Transform"), m_font);
+        painter.setFont(m_font);
+        painter.drawText(2, 20, tr("Fourier Transform"));
+        painter.end();
 
 		for(int i=0; i<int(win.size()); i++)
 			m_plan.in[i] = buff[i]*win[i];
@@ -298,8 +302,11 @@ void GLFT::paintGL()
 	{
 		glColor3f(0,0,0);
 
+        QPainter painter(this);
         m_font.setPixelSize(14);
-        renderText(width()/2, 12, m_text, m_font);
+        painter.setFont(m_font);
+        painter.drawText(width()/2, 12, m_text);
+        painter.end();
 	}
 
 	glFlush();

--- a/src/modules/GLFT.h
+++ b/src/modules/GLFT.h
@@ -24,12 +24,12 @@
 using namespace std;
 #include <Music/CFFTW3.h>
 // using namespace Music;
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <qspinbox.h>
 #include <qaction.h>
 #include "View.h"
 
-class GLFT : public QGLWidget, public View
+class GLFT : public QOpenGLWidget, public View
 {
 	Q_OBJECT
 

--- a/src/modules/GLFreqStruct.cpp
+++ b/src/modules/GLFreqStruct.cpp
@@ -24,11 +24,12 @@ using namespace std;
 #include <qimage.h>
 #include <qboxlayout.h>
 #include <qwidgetaction.h>
+#include <QPainter>
 #include <Music/Music.h>
 using namespace Music;
 
 GLFreqStruct::GLFreqStruct(QWidget* parent)
-: QGLWidget(parent)
+: QOpenGLWidget(parent)
 , View(tr("Harmonics"), this)
 , m_font("Helvetica")
 , m_components_max(1.0)
@@ -155,28 +156,31 @@ void GLFreqStruct::paintGL()
     }
 
     glColor3f(0.5f,0.5f,0.5f);
+    QPainter painter(this);
     m_font.setPixelSize(14);
+    painter.setFont(m_font);
     QFontMetrics fm(m_font);
     int dy = -fm.xHeight()/2;
     string sfraq = "-10dB";
-    renderText(2, 10*(height()-scale_height)/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 10*(height()-scale_height)/50-dy, QString(sfraq.c_str()));
     sfraq = "-20dB";
-    renderText(2, 20*(height()-scale_height)/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 20*(height()-scale_height)/50-dy, QString(sfraq.c_str()));
     sfraq = "-30dB";
-    renderText(2, 30*(height()-scale_height)/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 30*(height()-scale_height)/50-dy, QString(sfraq.c_str()));
     sfraq = "-40dB";
-    renderText(2, 40*(height()-scale_height)/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 40*(height()-scale_height)/50-dy, QString(sfraq.c_str()));
 
     // scale
     m_font.setPixelSize(10);
     glColor3f(0,0,0);
 	for(size_t i=0; i<m_components.size(); i++)
-        renderText(int((i+0.5)*step)+s-3, height()-2, QString::number(i+1), m_font);
+    	painter.drawText(int((i+0.5)*step)+s-3, height()-2, QString::number(i+1));
 
     // name
     glColor3f(0.75,0.75,0.75);
     m_font.setPixelSize(20);
-    renderText(2, 20, tr("Harmonics' amplitude"), m_font);
+    painter.drawText(2, 20, tr("Harmonics' amplitude"));
+    painter.end();
 
     glFlush();
 }

--- a/src/modules/GLFreqStruct.h
+++ b/src/modules/GLFreqStruct.h
@@ -22,12 +22,12 @@
 
 #include <vector>
 using namespace std;
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <qspinbox.h>
 #include <qaction.h>
 #include "View.h"
 
-class GLFreqStruct : public QGLWidget, public View
+class GLFreqStruct : public QOpenGLWidget, public View
 {
 	Q_OBJECT
 

--- a/src/modules/GLGraph.cpp
+++ b/src/modules/GLGraph.cpp
@@ -25,11 +25,12 @@ using namespace std;
 #include <qimage.h>
 #include <qboxlayout.h>
 #include <qwidgetaction.h>
+#include <QPainter>
 #include <Music/Music.h>
 using namespace Music;
 
 GLGraph::GLGraph(QWidget* parent)
-: QGLWidget(parent)
+: QOpenGLWidget(parent)
 , View(tr("Captured Sound"), this)
 , m_font("Helvetica")
 , m_skip(1)
@@ -247,7 +248,7 @@ void GLGraph::update_maxs()
 		m_maxs.push_back(make_pair(smin, smax));
 	}
 
-	updateGL();
+	update();
 }
 
 void GLGraph::base_paint(float graph_gray)
@@ -256,12 +257,15 @@ void GLGraph::base_paint(float graph_gray)
 
 // 	cout<<"m_pending_queue="<<m_pending_queue.size()<<" m_queue="<<m_queue.size()<<" m_maxs="<<m_maxs.size()<<endl;
 
-	int width = QGLWidget::width();
+	int width = QOpenGLWidget::width();
 
 	// name
 	glColor3f(0.75,0.75,0.75);
+	QPainter painter(this);
     m_font.setPixelSize(20);
-    renderText(2, 20, tr("Captured Sound"), m_font);
+    painter.setFont(m_font);
+    painter.drawText(2, 20, tr("Captured Sound"));
+    painter.end();
 
 	if(setting_showWaveForm->isChecked() && !m_queue.empty())
 	{

--- a/src/modules/GLGraph.h
+++ b/src/modules/GLGraph.h
@@ -22,14 +22,14 @@
 
 #include <deque>
 using namespace std;
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <qaction.h>
 #include <qspinbox.h>
 class QTimer;
 #include <Music/Music.h>
 #include "View.h"
 
-class GLGraph : public QGLWidget, public View
+class GLGraph : public QOpenGLWidget, public View
 {
 	Q_OBJECT
 

--- a/src/modules/GLSample.cpp
+++ b/src/modules/GLSample.cpp
@@ -27,9 +27,10 @@ using namespace std;
 #include <qimage.h>
 #include <qboxlayout.h>
 #include <qwidgetaction.h>
+#include <QPainter>
 
 GLSample::GLSample(QWidget* parent)
-: QGLWidget(parent)
+: QOpenGLWidget(parent)
 , View(tr("Waveform"), this)
 , m_font("Helvetica")
 , m_max_value(1.0)
@@ -41,7 +42,7 @@ GLSample::GLSample(QWidget* parent)
 
 	setting_hasFading = new QAction(tr("Show fading"), this);
 	setting_hasFading->setCheckable(true);
-	connect(setting_hasFading, SIGNAL(toggled(bool)), this, SLOT(updateGL()));
+	connect(setting_hasFading, SIGNAL(toggled(bool)), this, SLOT(update()));
 	m_popup_menu.addAction(setting_hasFading);
 
 	QHBoxLayout* numFadingActionLayout = new QHBoxLayout(&m_popup_menu);
@@ -55,7 +56,7 @@ GLSample::GLSample(QWidget* parent)
 	setting_spinNumFading->setSingleStep(1);
 	setting_spinNumFading->setValue(20);
 	setting_spinNumFading->setToolTip(tr("Number of fading"));
-	connect(setting_spinNumFading, SIGNAL(valueChanged(int)), this, SLOT(updateGL()));
+	connect(setting_spinNumFading, SIGNAL(valueChanged(int)), this, SLOT(update()));
 	numFadingActionLayout->addWidget(setting_spinNumFading);
 
 	QWidget* numFadingActionWidget = new QWidget(&m_popup_menu);
@@ -120,8 +121,11 @@ void GLSample::paintGL()
 
 	// name
 	glColor3f(0.75,0.75,0.75);
+	QPainter painter(this);
     m_font.setPixelSize(20);
-    renderText(2, 20, tr("Waveform's period"), m_font);
+    painter.setFont(m_font);
+    painter.drawText(2, 20, tr("Waveform's period"));
+    painter.end();
 
 	// horiz lines
 	glBegin(GL_LINES);

--- a/src/modules/GLSample.h
+++ b/src/modules/GLSample.h
@@ -22,13 +22,13 @@
 #include <deque>
 using namespace std;
 
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <qaction.h>
 #include <qspinbox.h>
 class QTimer;
 #include "View.h"
 
-class GLSample : public QGLWidget, public View
+class GLSample : public QOpenGLWidget, public View
 {
 	Q_OBJECT
 

--- a/src/modules/GLStatistics.cpp
+++ b/src/modules/GLStatistics.cpp
@@ -26,6 +26,7 @@ using namespace std;
 #include <qimage.h>
 #include <qboxlayout.h>
 #include <qwidgetaction.h>
+#include <QPainter>
 #include <Music/Music.h>
 
 void GLStatistics::AverageNote::init()
@@ -187,7 +188,7 @@ void GLStatistics::resizeScale()
 }
 
 GLStatistics::GLStatistics(QWidget* parent)
-: QGLWidget(parent)
+: QOpenGLWidget(parent)
 , View(tr("Statistics"), this)
 , m_font("Helvetica")
 {
@@ -361,7 +362,7 @@ void GLStatistics::reset()
 		setting_scale_max->setValue(0);
 	}
 	resizeScale();
-	updateGL();
+	update();
 }
 
 void GLStatistics::initializeGL()
@@ -397,7 +398,9 @@ void GLStatistics::drawTextTickCent(int r, int dy)
 	// only work within range that is a pure multiple of r
 	int range = int(setting_spinScale->value()/r)*r;
 
+    QPainter painter(this);
     m_font.setPixelSize(14);
+    painter.setFont(m_font);
     QFontMetrics fm(m_font);
 
 	float scale = 50.0f/setting_spinScale->value();
@@ -407,8 +410,9 @@ void GLStatistics::drawTextTickCent(int r, int dy)
 		txt = QString::number(i);
 		if(i>=0) txt = QString("  ")+txt;
 		if(i==0) txt = QString("  ")+txt;
-        renderText(2, (height()-dy)/2 - int((height()-dy)*i/100.0f*scale) +fm.xHeight()/2, txt, m_font);
+        painter.drawText(2, (height()-dy)/2 - int((height()-dy)*i/100.0f*scale) +fm.xHeight()/2, txt);
 	}
+	painter.end();
 }
 
 void GLStatistics::paintGL()
@@ -427,8 +431,11 @@ void GLStatistics::paintGL()
 
 	// name
 	glColor3f(0.75,0.75,0.75);
+	QPainter painter(this);
     m_font.setPixelSize(20);
-    renderText(2, 20, tr("Statistics"), m_font);
+    painter.setFont(m_font);
+    painter.drawText(2, 20, tr("Statistics"));
+    painter.end();
 
 	int char_size = 9;
 	int ticks_size = 2+3*char_size;
@@ -547,19 +554,22 @@ void GLStatistics::paintGL()
 	}
 	else
 	{
+	    painter.begin(this);
         m_font.setPixelSize(14);
+        painter.setFont(m_font);
         QFontMetrics fm(m_font);
         string sfraq, sufraq;
 		sufraq = string("1/")+QString::number(int(50/setting_spinScale->value())*2).toStdString();
         sfraq = string("-")+sufraq;
-        renderText(2, 3*grid_height/4+fm.xHeight()/2, QString(sfraq.c_str()), m_font);
+        painter.drawText(2, 3*grid_height/4+fm.xHeight()/2, QString(sfraq.c_str()));
         sfraq = string("+")+sufraq;
-        renderText(2, grid_height/4+fm.xHeight()/2, QString(sfraq.c_str()), m_font);
+        painter.drawText(2, grid_height/4+fm.xHeight()/2, QString(sfraq.c_str()));
 		sufraq = string("1/")+QString::number(int(50/setting_spinScale->value())*4).toStdString();
         sfraq = string("-")+sufraq;
-        renderText(2, 5*grid_height/8+fm.xHeight()/2, QString(sfraq.c_str()), m_font);
+        painter.drawText(2, 5*grid_height/8+fm.xHeight()/2, QString(sfraq.c_str()));
         sfraq = string("+")+sufraq;
-        renderText(2, 3*grid_height/8+fm.xHeight()/2, QString(sfraq.c_str()), m_font);
+        painter.drawText(2, 3*grid_height/8+fm.xHeight()/2, QString(sfraq.c_str()));
+        painter.end();
 	}
 
 	// vertical lines
@@ -576,14 +586,16 @@ void GLStatistics::paintGL()
 
 	// note names
 	glColor3f(0, 0, 1);
+	painter.begin(this);
     m_font.setPixelSize(14);
+    painter.setFont(m_font);
     QFontMetrics fm(m_font);
     for(size_t i=0; i<m_avg_notes.size(); i++)
 	{
         QString str = m_avg_notes[i].getName();
 
         QRect rect = fm.boundingRect(str);
-        renderText(ticks_size+(i+0.5)*float(grid_width)/m_avg_notes.size()-rect.width()/2, height()-4-17, str, m_font);
+        painter.drawText(ticks_size+(i+0.5)*float(grid_width)/m_avg_notes.size()-rect.width()/2, height()-4-17, str);
 	}
 
 	// sizes
@@ -595,9 +607,10 @@ void GLStatistics::paintGL()
             QString str = QString::number(m_avg_notes[i].errs.size());
 
             QRect rect = fm.boundingRect(str);
-            renderText(ticks_size+(i+0.5)*float(grid_width)/m_avg_notes.size()-rect.width()/2, height()-4, str, m_font);
+            painter.drawText(ticks_size+(i+0.5)*float(grid_width)/m_avg_notes.size()-rect.width()/2, height()-4, str);
 		}
 	}
+	painter.end();
 
 	// means
 	glLineWidth(2.0f);

--- a/src/modules/GLStatistics.h
+++ b/src/modules/GLStatistics.h
@@ -23,7 +23,7 @@
 
 #include <deque>
 using namespace std;
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <qspinbox.h>
 #include <qsettings.h>
 #include <qaction.h>
@@ -31,7 +31,7 @@ class QTimer;
 #include <Music/Music.h>
 #include "View.h"
 
-class GLStatistics : public QGLWidget, public View
+class GLStatistics : public QOpenGLWidget, public View
 {
 	Q_OBJECT
 

--- a/src/modules/GLVolumeHistory.cpp
+++ b/src/modules/GLVolumeHistory.cpp
@@ -22,6 +22,7 @@
 using namespace std;
 #include <qtimer.h>
 #include <qimage.h>
+#include <QPainter>
 #include <Music/Music.h>
 
 GLVolumeHistory::Note::Note(int h)
@@ -44,7 +45,7 @@ QString GLVolumeHistory::Note::getName() const
 }
 
 GLVolumeHistory::GLVolumeHistory(QWidget* parent)
-: QGLWidget(parent)
+: QOpenGLWidget(parent)
 , View(tr("Volume history"), this)
 , m_font("Helvetica")
 {
@@ -121,8 +122,11 @@ void GLVolumeHistory::paintGL()
 
 	// name
 	glColor3f(0.75,0.75,0.75);
+	QPainter painter(this);
     m_font.setPixelSize(20);
-    renderText(2, 20, tr("Volume"), m_font);
+    painter.setFont(m_font);
+    painter.drawText(2, 20, tr("Volume"));
+    painter.end();
 
 	int s = 2+fontMetrics().width("50%");
 
@@ -153,19 +157,22 @@ void GLVolumeHistory::paintGL()
 	}
 
 	glColor3f(0.5f,0.5f,0.5f);
+	painter.begin(this);
     m_font.setPixelSize(14);
+    painter.setFont(m_font);
     QFontMetrics fm(m_font);
     int dy = -fm.xHeight()/2;
     string sfraq = "[dB]";
-    renderText(2, height()-2, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, height()-2, QString(sfraq.c_str()));
     sfraq = "-10";
-    renderText(2, 10*height()/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 10*height()/50-dy, QString(sfraq.c_str()));
 	sfraq = "-20";
-    renderText(2, 20*height()/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 20*height()/50-dy, QString(sfraq.c_str()));
 	sfraq = "-30";
-    renderText(2, 30*height()/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 30*height()/50-dy, QString(sfraq.c_str()));
 	sfraq = "-40";
-    renderText(2, 40*height()/50-dy, QString(sfraq.c_str()), m_font);
+    painter.drawText(2, 40*height()/50-dy, QString(sfraq.c_str()));
+    painter.end();
 
 	glColor3f(1.0,0.5,0.5);
 	glLineWidth(2.0f);
@@ -203,8 +210,11 @@ void GLVolumeHistory::paintGL()
 			// the note name
 			string str = Music::h2n(m_notes[i].ht);
 			glColor3f(0.0,0.0,1.0);
+			painter.begin(this);
             m_font.setPixelSize(14);
-            renderText(x+2, height()-2, QString(str.c_str()), m_font);
+            painter.setFont(m_font);
+            painter.drawText(x+2, height()-2, QString(str.c_str()));
+            painter.end();
 
 			// draw the volume graph
 			if(!m_notes[i].volumes.empty())

--- a/src/modules/GLVolumeHistory.h
+++ b/src/modules/GLVolumeHistory.h
@@ -23,12 +23,12 @@
 
 #include <deque>
 using namespace std;
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <qaction.h>
 class QTimer;
 #include "View.h"
 
-class GLVolumeHistory : public QGLWidget, public View
+class GLVolumeHistory : public QOpenGLWidget, public View
 {
 	Q_OBJECT
 


### PR DESCRIPTION
QOpenGLWidget is the modern replacement and has several advantages. In
this case, it fixes #86.

The only big change needed was replacing renderText calls with
QPainter::drawText ones.