### PR TITLE
Improvements to transposition setting (aka Tonality)

### DIFF
--- a/libs/Music/Music.cpp
+++ b/libs/Music/Music.cpp
@@ -25,7 +25,7 @@ using namespace std;
 
 Music::NotesName Music::s_notes_name = Music::LOCAL_ANGLO;
 
-int Music::s_tonality = 0;
+int Music::s_transposition = 0;
 double Music::s_semitones[13] = { 1.0000, 1.0595, 1.1225, 1.1892, 1.2599, 1.3348, 1.4142, 1.4983, 1.5874, 1.6818, 1.7818, 1.8877, 2.0000 }; // Chromatic, never used
 static double semitones_werckmeister3[] = { 1.0, 1.06425952556, 1.125, 1.19729196625, 1.26134462288, 1.33785800438, 1.41901270074, 1.5, 1.59638928833, 1.68179283051, 1.78986403988, 1.89201693432, 2.0 };
 static double semitones_kirnberger3[] = { 1.0, 1.06335913331, 1.12151158592, 1.19627902498, 1.26027749133, 1.33748060995, 1.41781217775, 1.49534878122, 1.59503869997, 1.68036998845, 1.788854382, 1.890416237, 2.0 };

--- a/libs/Music/Music.h
+++ b/libs/Music/Music.h
@@ -39,9 +39,9 @@ namespace Music
 	inline NotesName GetNotesName()					{return s_notes_name;}
 	inline void SetNotesName(NotesName type)		{s_notes_name = type;}
 
-	extern int s_tonality;
-	inline int GetTonality()						{return s_tonality;}
-	inline void SetTonality(int tonality)			{s_tonality = tonality;}
+	extern int s_transposition;
+	inline int GetTransposition()						{return s_transposition;}
+	inline void SetTransposition(int transposition)	    {s_transposition = transposition;}
 
 	enum Tuning{CHROMATIC,WERCKMEISTER3,KIRNBERGER3,DIATONIC,MEANTONE};
 	extern Tuning s_tuning;
@@ -206,11 +206,11 @@ namespace Music
 	* \param local
 	* \return its name (Do, Re, Mi, Fa, Sol, La, Si; with '#' or 'b' if needed)
 	*/
-	inline string h2n(int ht, NotesName local=GetNotesName(), int tonality=GetTonality(), int tunig=GetTuning(), bool show_oct=true)
+	inline string h2n(int ht, NotesName local=GetNotesName(), int transposition=GetTransposition(), int tunig=GetTuning(), bool show_oct=true)
 	{
         (void)tunig;
 
-		ht += tonality;
+		ht += transposition;
 
 		int oct = 4;
 		while(ht<0)
@@ -314,7 +314,7 @@ namespace Music
 		return "Th#1138";
 	}
 
-//	inline int n2h(const std::string& note, NotesName local=LOCAL_ANGLO, int tonality=GetTonality())
+//	inline int n2h(const std::string& note, NotesName local=LOCAL_ANGLO, int transposition=GetTransposition())
 //	{
 //		// TODO
 //		return -1;

--- a/src/CustomInstrumentTunerForm.cpp
+++ b/src/CustomInstrumentTunerForm.cpp
@@ -79,7 +79,7 @@ CustomInstrumentTunerForm::CustomInstrumentTunerForm()
 	m_settings.add(m_config_form.ui_chkShowA4Offset);
 
 	m_settings.add(m_config_form.ui_cbTuning);
-	m_settings.add(m_config_form.ui_cbTonality);
+	m_settings.add(m_config_form.ui_cbTransposition);
 	m_settings.add(m_config_form.ui_cbNotesName);
 	m_settings.add(ui_spinAFreq);
 	m_settings.add(ui_spinA3Offset);
@@ -234,7 +234,7 @@ CustomInstrumentTunerForm::CustomInstrumentTunerForm()
 	connect(m_config_form.ui_spinMinHT, SIGNAL(valueChanged(int)), this, SLOT(noteRangeChanged()));
 	connect(m_config_form.ui_spinMaxHT, SIGNAL(valueChanged(int)), this, SLOT(noteRangeChanged()));
 	connect(m_config_form.ui_cbTuning, SIGNAL(highlighted(int)), this, SLOT(noteRangeChanged()));
-	connect(m_config_form.ui_cbTonality, SIGNAL(highlighted(int)), this, SLOT(noteRangeChanged()));
+	connect(m_config_form.ui_cbTransposition, SIGNAL(highlighted(int)), this, SLOT(noteRangeChanged()));
 	connect(m_config_form.ui_cbNotesName, SIGNAL(highlighted(int)), this, SLOT(noteRangeChanged()));
 	connect(m_config_form.ui_btnAutoDetect, SIGNAL(clicked()), this, SLOT(autoDetectTransport()));
 	connect(m_config_form.ui_cbTransports, SIGNAL(activated(const QString&)), this, SLOT(selectTransport(const QString&)));
@@ -813,10 +813,10 @@ void CustomInstrumentTunerForm::configure_ok()
 		break;
 	}
 
-	if(m_config_form.ui_cbTonality->currentIndex()==0)		SetTonality(0);
-	else if(m_config_form.ui_cbTonality->currentIndex()==1)	SetTonality(+2);
-    else if(m_config_form.ui_cbTonality->currentIndex()==2)	SetTonality(-3);
-    else if(m_config_form.ui_cbTonality->currentIndex()==3)	SetTonality(-5);
+	if(m_config_form.ui_cbTransposition->currentIndex()==0)		SetTransposition(0);
+	else if(m_config_form.ui_cbTransposition->currentIndex()==1)	SetTransposition(+2);
+    else if(m_config_form.ui_cbTransposition->currentIndex()==2)	SetTransposition(-3);
+    else if(m_config_form.ui_cbTransposition->currentIndex()==3)	SetTransposition(-5);
 
 	if(m_config_form.ui_cbNotesName->currentIndex()==0)		SetNotesName(LOCAL_ANGLO);
 	if(m_config_form.ui_cbNotesName->currentIndex()==1)		SetNotesName(LOCAL_LATIN);
@@ -1165,19 +1165,20 @@ CustomInstrumentTunerForm::~CustomInstrumentTunerForm()
 
 void CustomInstrumentTunerForm::update_localized_note_names()
 {
-    m_config_form.ui_cbTonality->clear();
-	m_config_form.ui_cbTonality->addItem(QString::fromStdString(h2n(3, GetNotesName(), 0, CHROMATIC, false))); // C
-	m_config_form.ui_cbTonality->addItem(QString::fromStdString(h2n(1, GetNotesName(), 0, CHROMATIC, false))); // Eb
-	m_config_form.ui_cbTonality->addItem(QString::fromStdString(h2n(6, GetNotesName(), 0, CHROMATIC, false))); // Bb
-	m_config_form.ui_cbTonality->addItem(QString::fromStdString(h2n(8, GetNotesName(), 0, CHROMATIC, false))); // F
+    m_config_form.ui_cbTransposition->clear();
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(3, GetNotesName(), 0, CHROMATIC, false))); // C
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(1, GetNotesName(), 0, CHROMATIC, false))); // Eb
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(6, GetNotesName(), 0, CHROMATIC, false))); // Bb
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(8, GetNotesName(), 0, CHROMATIC, false))); // F
 
-	QString tonalityToolTip = tr("The used tonality.\nUseful to convert note names to a corresponding instrument tonality (e.g. %1 for saxophone, %2 for trumpet).")
+	QString transpositionToolTip = tr("Transposition of %1.\nUseful to convert note names to a corresponding transposing instrument (e.g. %2 for saxophone, %3 for trumpet).")
+	        .arg(QString::fromStdString(h2n(3, GetNotesName(), 0, CHROMATIC, false))) // C
 			.arg(QString::fromStdString(h2n(1, GetNotesName(), 0, CHROMATIC, false))) // Eb
 			.arg(QString::fromStdString(h2n(6, GetNotesName(), 0, CHROMATIC, false))); // Bb
-	m_config_form.textLabel1_7->setToolTip(tonalityToolTip);
-	m_config_form.textLabel1_7->setWhatsThis(tonalityToolTip);
-	m_config_form.ui_cbTonality->setToolTip(tonalityToolTip);
-	m_config_form.ui_cbTonality->setWhatsThis(tonalityToolTip);
+	m_config_form.textLabel1_7->setToolTip(transpositionToolTip);
+	m_config_form.textLabel1_7->setWhatsThis(transpositionToolTip);
+	m_config_form.ui_cbTransposition->setToolTip(transpositionToolTip);
+	m_config_form.ui_cbTransposition->setWhatsThis(transpositionToolTip);
 
 	QString a4Name = QString::fromStdString(h2n(0, GetNotesName(), 0, CHROMATIC, true));
 

--- a/src/CustomInstrumentTunerForm.cpp
+++ b/src/CustomInstrumentTunerForm.cpp
@@ -79,6 +79,11 @@ CustomInstrumentTunerForm::CustomInstrumentTunerForm()
 	m_settings.add(m_config_form.ui_chkShowA4Offset);
 
 	m_settings.add(m_config_form.ui_cbTuning);
+	// must fill items before adding to settings, else previous value will be lost
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(3, GetNotesName(), 0, CHROMATIC, false))); // C
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(1, GetNotesName(), 0, CHROMATIC, false))); // Eb
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(6, GetNotesName(), 0, CHROMATIC, false))); // Bb
+	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(8, GetNotesName(), 0, CHROMATIC, false))); // F
 	m_settings.add(m_config_form.ui_cbTransposition);
 	m_settings.add(m_config_form.ui_cbNotesName);
 	m_settings.add(ui_spinAFreq);
@@ -1165,11 +1170,11 @@ CustomInstrumentTunerForm::~CustomInstrumentTunerForm()
 
 void CustomInstrumentTunerForm::update_localized_note_names()
 {
-    m_config_form.ui_cbTransposition->clear();
-	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(3, GetNotesName(), 0, CHROMATIC, false))); // C
-	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(1, GetNotesName(), 0, CHROMATIC, false))); // Eb
-	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(6, GetNotesName(), 0, CHROMATIC, false))); // Bb
-	m_config_form.ui_cbTransposition->addItem(QString::fromStdString(h2n(8, GetNotesName(), 0, CHROMATIC, false))); // F
+    //m_config_form.ui_cbTransposition->clear();
+    m_config_form.ui_cbTransposition->setItemText(0, QString::fromStdString(h2n(3, GetNotesName(), 0, CHROMATIC, false))); // C
+	m_config_form.ui_cbTransposition->setItemText(1, QString::fromStdString(h2n(1, GetNotesName(), 0, CHROMATIC, false))); // Eb
+	m_config_form.ui_cbTransposition->setItemText(2, QString::fromStdString(h2n(6, GetNotesName(), 0, CHROMATIC, false))); // Bb
+	m_config_form.ui_cbTransposition->setItemText(3, QString::fromStdString(h2n(8, GetNotesName(), 0, CHROMATIC, false))); // F
 
 	QString transpositionToolTip = tr("Transposition of %1.\nUseful to convert note names to a corresponding transposing instrument (e.g. %2 for saxophone, %3 for trumpet).")
 	        .arg(QString::fromStdString(h2n(3, GetNotesName(), 0, CHROMATIC, false))) // C

--- a/src/CustomInstrumentTunerForm.h
+++ b/src/CustomInstrumentTunerForm.h
@@ -140,6 +140,7 @@ public slots:
     virtual void configure_cancel();
 	virtual void restoreFactorySettings();
 	virtual void noteRangeChanged();
+	virtual void transpositionChanged();
 	virtual void selectTransport(const QString & name);
 	virtual void autoDetectTransport();
 	void refresh();

--- a/src/modules/MicrotonalView.cpp
+++ b/src/modules/MicrotonalView.cpp
@@ -268,7 +268,7 @@ QRoot::QRoot(MicrotonalView* view, int ht)
 	connect(this, SIGNAL(clicked()), this, SLOT(clicked2()));
 	connect(this, SIGNAL(rootClicked(int)), view, SLOT(selectRoot(int)));
 	setFlat(true);
-	setText(QString::fromStdString(h2n(ht, GetNotesName(), GetTonality(), false)));
+	setText(QString::fromStdString(h2n(ht, GetNotesName(), GetTransposition(), false)));
 	setCheckable(true);
 	setSizePolicy(QSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed));
 	setMinimumWidth(55);		// TODO
@@ -514,7 +514,7 @@ int MicrotonalView::getIndex(MScale* scale)
 void MicrotonalView::notesNameChanged()
 {
 	for(int i=0; i<13; i++)
-		m_roots[i]->setText(QString::fromStdString(h2n(m_roots[i]->m_ht, GetNotesName(), GetTonality(), false)));
+		m_roots[i]->setText(QString::fromStdString(h2n(m_roots[i]->m_ht, GetNotesName(), GetTransposition(), false)));
 }
 
 void MicrotonalView::keepRootToLeft(bool keep)

--- a/ui/ConfigForm.ui
+++ b/ui/ConfigForm.ui
@@ -125,12 +125,12 @@
          <item>
           <widget class="QLabel" name="textLabel1_7">
            <property name="text">
-            <string>Tonality</string>
+            <string>Transposition</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="ui_cbTonality">
+          <widget class="QComboBox" name="ui_cbTransposition">
           </widget>
          </item>
         </layout>

--- a/ui/ConfigForm.ui
+++ b/ui/ConfigForm.ui
@@ -130,8 +130,25 @@
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="ui_cbTransposition">
-          </widget>
+          <layout class="QVBoxLayout">
+           <item>
+            <widget class="QSpinBox" name="ui_spinTransposition">
+             <property name="minimum">
+              <number>-96</number>
+             </property>
+             <property name="maximum">
+              <number>96</number>
+             </property>
+             <property name="value">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="ui_lblTransposition">
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>


### PR DESCRIPTION
I saw [here](https://en.wikipedia.org/wiki/List_of_transposing_instruments) that there are lots of transposing instruments, for a wide range of semitones. Based on that, I think that it might be nice to allow a free-form setting, as a QSpinBox, allowing the user to pick whatever offset they want, instead of a fixed list. 

What do you think?

- The first commit simply renames Tonality -> Transposition. 
- Second commit fixes an issue introduced in https://github.com/gillesdegottex/fmit/commit/5975900ec4011627fba99f59f1f273ab149de3f6. 
- Third commit replaces the QComboBox with QSpinBox + QLabel.