### PR TITLE
Help AppStream process translations

### DIFF
--- a/distrib/fmit.appdata.xml.in
+++ b/distrib/fmit.appdata.xml.in
@@ -79,6 +79,7 @@
   <url type="faq">http://gillesdegottex.github.io/fmit/faq.html</url>
   <developer_name>Gilles Degottex</developer_name>
   <updatecontact>gilles.degottex@gmail.com</updatecontact>
+  <translation type="qt">fmit</translation>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>
     <content_attribute id="violence-fantasy">none</content_attribute>

--- a/fmit.pro
+++ b/fmit.pro
@@ -265,7 +265,7 @@ linux {
 # Installation configurations --------------------------------------------------
 scales.path = $$PREFIX/share/fmit/scales
 scales.files = scales/*
-translations.path = $$PREFIX/share/fmit/tr
+translations.path = $$PREFIX/share/fmit/translations
 translations.files = tr/*.qm
 target.path = $$PREFIX/bin
 shortcut.path = $$PREFIXSHORTCUT/share/applications

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
     #ifdef Q_OS_WIN32
         QString trPath = QCoreApplication::applicationDirPath()+"/";
     #else
-        QString trPath = fmitprefix + QString("/share/fmit/tr");
+        QString trPath = fmitprefix + QString("/share/fmit/translations");
     #endif
     cout << "INFO: Loading FMIT translation file: " << trFile.toLatin1().constData() << " in " << trPath.toLatin1().constData() << endl;
     fmitTranslator.load(trFile, trPath);


### PR DESCRIPTION
Install .qm files under $prefix/share/fmit/translations and add a
<translation> tag to appdata.

This will help app stores (e.g. Flathub, GNOME Software, etc.) to know in which languages FMIT is available.