### PR TITLE
AppData translation fix + update

### DIFF
--- a/distrib/appdata_tr/appdata.pot
+++ b/distrib/appdata_tr/appdata.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-20 02:13-0300\n"
+"POT-Creation-Date: 2018-05-30 14:56-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,32 +100,52 @@ msgid "Gilles Degottex"
 msgstr ""
 
 #. (itstool) path: ul/li
-#: fmit.appdata.xml.in:115
+#: fmit.appdata.xml.in:116
 msgid "New note names: Hindustani, Byzantine"
 msgstr ""
 
 #. (itstool) path: ul/li
-#: fmit.appdata.xml.in:116
+#: fmit.appdata.xml.in:117
 msgid "Use unicode flat and sharp signs"
 msgstr ""
 
 #. (itstool) path: ul/li
-#: fmit.appdata.xml.in:117
+#: fmit.appdata.xml.in:118
 msgid "Use custom save settings and pause icons that better fits the other icons design"
 msgstr ""
 
 #. (itstool) path: ul/li
-#: fmit.appdata.xml.in:124
+#: fmit.appdata.xml.in:119
+msgid "Flexible transposition key selection."
+msgstr ""
+
+#. (itstool) path: ul/li
+#: fmit.appdata.xml.in:120
+msgid "Added symbolic icon for high-contrast setup."
+msgstr ""
+
+#. (itstool) path: ul/li
+#: fmit.appdata.xml.in:121
+msgid "Switch to Weblate for translation: https://hosted.weblate.org/projects/fmit/"
+msgstr ""
+
+#. (itstool) path: ul/li
+#: fmit.appdata.xml.in:122
+msgid "Added translation for application information."
+msgstr ""
+
+#. (itstool) path: ul/li
+#: fmit.appdata.xml.in:129
 msgid "New icons"
 msgstr ""
 
 #. (itstool) path: ul/li
-#: fmit.appdata.xml.in:125
+#: fmit.appdata.xml.in:130
 msgid "Added F tonality"
 msgstr ""
 
 #. (itstool) path: ul/li
-#: fmit.appdata.xml.in:126
+#: fmit.appdata.xml.in:131
 msgid "Fixed graphical glitches"
 msgstr ""
 

--- a/distrib/fmit.appdata.xml.in
+++ b/distrib/fmit.appdata.xml.in
@@ -110,12 +110,16 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="1.2.1" date="2018-05-14">
+    <release version="1.2.6" date="2018-05-30">
       <description>
         <ul>
           <li>New note names: Hindustani, Byzantine</li>
           <li>Use unicode flat and sharp signs</li>
           <li>Use custom save settings and pause icons that better fits the other icons design</li>
+          <li>Flexible transposition key selection.</li>
+          <li>Added symbolic icon for high-contrast setup.</li>
+          <li>Switch to Weblate for translation: https://hosted.weblate.org/projects/fmit/</li>
+          <li>Added translation for application information.</li>
         </ul>
       </description>
     </release>

--- a/distrib/update_appdata_tr.sh
+++ b/distrib/update_appdata_tr.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+
+itstool -i as-metainfo.its -o appdata_tr/appdata.pot fmit.appdata.xml.in

--- a/fmit.pro
+++ b/fmit.pro
@@ -246,12 +246,14 @@ QMAKE_EXTRA_TARGETS += lrelease
 linux {
     appdata_po.target = $$OUT_PWD/%.mo
     appdata_po.depends = $$PWD/%.po
-    appdata_po.commands = $$QMAKE_MKDIR_CMD $(dir $@) && msgfmt $< -o $@
+    appdata_po.commands = $$sprintf($$QMAKE_MKDIR_CMD, $(dir $@)) && msgfmt $< -o $@
     QMAKE_EXTRA_TARGETS += appdata_po
 
-    appdata_tr.depends = $$PWD/distrib/fmit.appdata.xml.in $(patsubst $$PWD/%.po,$$OUT_PWD/%.mo,$(wildcard $$PWD/distrib/appdata_tr/*.po))
+    APPDATA_MO = $(patsubst $$PWD/%.po,$$OUT_PWD/%.mo,$(wildcard $$PWD/distrib/appdata_tr/*.po))
+
+    appdata_tr.depends = $$PWD/distrib/fmit.appdata.xml.in $$APPDATA_MO
     appdata_tr.target = $$OUT_PWD/distrib/fmit.appdata.xml
-    appdata_tr.commands = $$sprintf($$QMAKE_MKDIR_CMD, $$OUT_PWD/distrib/) && itstool -j $$PWD/distrib/fmit.appdata.xml.in -o $@ $(wildcard $$OUT_PWD/distrib/appdata_tr/*.mo)
+    appdata_tr.commands = $$sprintf($$QMAKE_MKDIR_CMD, $$OUT_PWD/distrib/) && itstool -j $$PWD/distrib/fmit.appdata.xml.in -o $@ $$APPDATA_MO
     QMAKE_EXTRA_TARGETS += appdata_tr
     PRE_TARGETDEPS += $$appdata_tr.target
 } else {


### PR DESCRIPTION
Hi, sorry for bothering you once again :). 

It seems I missed a bug in fmit.pro that only showed when building the flatpak bundle. I think I fixed all the cases now.

I've also added the latest release notes to the appdata and updated the translatable strings.

After this, I'll wait a week or so to give translators some time and then I'll update the Flathub release.

Thanks!